### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Gulp
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/moussebathily/afrikoin-app/security/code-scanning/2](https://github.com/moussebathily/afrikoin-app/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a typical build workflow that only checks out code and installs dependencies, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies to a specific job). The best way is to add the following at the top level of the workflow file, just after the `name` field and before the `on` field. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
