### PR TITLE
chore(android): remove package attribute from manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="Afrikoin"
+        android:theme="@style/Theme.Afrikoin">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>


### PR DESCRIPTION
## Summary
- remove deprecated `package` attribute from `AndroidManifest.xml`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6891f9febdf48325a7294743109ce292