### PR TITLE
fix: correct tailwind dark mode and plugin import

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,9 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
-	darkMode: ["class"],
+        darkMode: "class",
 	content: [
 		"./pages/**/*.{ts,tsx}",
 		"./components/**/*.{ts,tsx}",
@@ -109,5 +110,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix tailwind dark mode config by using string "class"
- switch tailwindcss-animate plugin to ESM import

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_6891392ab90883259ffb27b11cdf6036